### PR TITLE
Export public functions

### DIFF
--- a/src/Retriever.jl
+++ b/src/Retriever.jl
@@ -1,6 +1,8 @@
 module Retriever
 using PyCall
 
+export check_for_updates, dataset_names, download, install_csv, install_mysql, install_postgres, install_sqlite, install_msaccess, install_json, install_xml, reset_retriever
+
 @pyimport retriever as rt
 
 """


### PR DESCRIPTION
There are two ways that packages are loaded in Julia. One of the is `using`,
which only loads functions that are explicitly exported. This exports all of our
functions to support this method of loading packages.