### PR TITLE
Add support for Julia 1.0+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:0.7.0-stretch
+FROM julia:1.1.1-stretch
 
 MAINTAINER weecology "https://github.com/weecology/Retriever.jl"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ WORKDIR /Retriever.jl
 RUN julia -e 'using InteractiveUtils; versioninfo()'
 RUN julia -e 'using Pkg;Pkg.update()'
 RUN julia -e 'using Pkg; Pkg.add("PyCall")'
-RUN julia -e 'Pkg.add("DocumenterTools")'
+RUN julia -e 'using Pkg; Pkg.add("DocumenterTools")'
 RUN echo $PYTHON
 RUN echo $JULIA_LOAD_PATH
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,6 @@
 push!(LOAD_PATH,"../src/Retriever.jl")
 include("../src/Retriever.jl")
 
-Pkg.add("Documenter")
 using Documenter, DocumenterTools
 
 makedocs(

--- a/src/Retriever.jl
+++ b/src/Retriever.jl
@@ -1,6 +1,5 @@
 module Retriever
 
-using Pkg
 using PyCall
 
 export check_for_updates, dataset_names, download

--- a/src/Retriever.jl
+++ b/src/Retriever.jl
@@ -7,7 +7,12 @@ export install_csv, install_mysql, install_postgres
 export install_sqlite, install_msaccess, install_json
 export install_xml, reset_retriever
 
-rt = pyimport("retriever")
+# Create retriever as rt while properly handling precompilation
+# See: https://github.com/JuliaPy/PyCall.jl#using-pycall-from-julia-modules
+const rt = PyNULL()
+function __init__()
+    copy!(rt, pyimport("retriever"))
+end
 
 """
 ```julia

--- a/src/Retriever.jl
+++ b/src/Retriever.jl
@@ -8,7 +8,7 @@ export install_csv, install_mysql, install_postgres
 export install_sqlite, install_msaccess, install_json
 export install_xml, reset_retriever
 
-@pyimport retriever as rt
+rt = pyimport("retriever")
 
 """
 ```julia

--- a/test/test_retriever.jl
+++ b/test/test_retriever.jl
@@ -4,7 +4,7 @@ using PyCall
 using SQLite
 using MySQL
 
-@pyimport os
+os = pyimport("os")
 
 Retriever.check_for_updates()
 


### PR DESCRIPTION
Will require Julia 1.0+, which is in line with my suggestion in #39 that we not try to support pre-1.0 releases none of which are maintained any more.