### PR TITLE
Autobuild docs using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,26 @@ warnings_are_errors: false
 
 services:
   - docker
-before_install:
--  docker-compose  run retrieverj
-script:
--  docker-compose run --service-ports retrieverj julia test/runtests.jl || exit 1
+
+stages:
+  - test
+  - name: documentation
+    if: branch = master
+
+jobs:
+  include:
+    - stage: test
+      before_install:
+        -  docker-compose run retrieverj
+      script:
+        -  docker-compose run --service-ports retrieverj julia test/runtests.jl || exit 1
+
+    - stage: documentation
+      language: julia
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
+                                               Pkg.instantiate()'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
       julia: 1.0
       os: linux
       script:
+        - julia --project=docs/ -e 'using Pkg; ENV["PYTHON"]=""; Pkg.add("PyCall")'
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
                                                Pkg.instantiate()'
         - julia --project=docs/ docs/make.jl

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,5 @@ deploydocs(
     repo = "github.com/weecology/Retriever.jl.git",
     target = "build",
     deps = nothing,
-    julia = "",
     make = nothing
 )

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -9,7 +9,7 @@ This allows data analysts to spend a majority of their time in analysing rather 
 
 ## Installation
 
-To use Retriever, you first need to [install Retriever](http://www.data-retriever.org), a core python package.
+To use Retriever, you first need to [install Retriever](https://www.data-retriever.org), a core python package.
 
 To install Retriever using the Julia package manager
 
@@ -20,7 +20,7 @@ julia> Pkg.add("Retriever")
 
 ```
 
-To install from Source, download or checkout the source from the [github page](https://github.com/weecology/Retriever.jl.git).
+To install from Source, download or checkout the source from the [github page](https://github.com/weecology/Retriever.jl).
 
 Go to `Retriever.jl/src`. Run Julia.
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,13 +1,13 @@
 # Data Retriever using Julia
 
-The wrapper module for [Data Retriever](http://data-retriever.org) has been implemented as [Retriever](https://github.com/weecology/Retriever.jl.git).
+The wrapper module for [Data Retriever](https://www.data-retriever.org) has been implemented as [Retriever](https://github.com/weecology/Retriever.jl.git).
 All the functions work and feel the same as the python Retriever module.
 The module has been created using ``PyCall`` hence all the functions are analogous to the functions of Retriever python module.
 
 
 ## Installation
 
-To use Retriever, you first need to [install Retriever](http://www.data-retriever.org), a core python package.
+To use Retriever, you first need to [install Retriever](https://www.data-retriever.org), a core python package.
 
 To install Retriever using the Julia package manager
 
@@ -19,7 +19,7 @@ To install Retriever using the Julia package manager
 ```
 
 
-To install from Source, download or checkout the source from the [github page](https://github.com/weecology/Retriever.jl.git).
+To install from Source, download or checkout the source from the [github page](https://github.com/weecology/Retriever.jl).
 
 Go to `Retriever.jl/src`. Run Julia.
 

--- a/src/Retriever.jl
+++ b/src/Retriever.jl
@@ -11,7 +11,7 @@ export install_xml, reset_retriever
 # See: https://github.com/JuliaPy/PyCall.jl#using-pycall-from-julia-modules
 const rt = PyNULL()
 function __init__()
-    copy!(rt, pyimport("retriever"))
+    copy!(rt, pyimport_conda("retriever", "retriever", "conda-forge"))
 end
 
 """


### PR DESCRIPTION
To accomplish this required getting a successful build of the core retriever running in Travis without docker.
To do this required switching from `pyimport` to `pyimport_conda` and setting Travis build PyCall
to support the use of Python packages using Julia's built in conda install. This has wider benefits
for ease of user installation (details to be PR'd separately).