### PR TITLE
Update links for docs badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 |:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
 | [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] |[![][license-img]][license-url]   | [![][travis-img]][travis-url] |
 
-[docs-stable-img]: https://img.shields.io/badge/docs-latest-blue.svg
-[docs-stable-url]: https://weecology.github.io/Retriever.jl/latest/intro.html
-[docs-latest-img]: https://readthedocs.org/projects/retrieverjl/badge/?version=latest
-[docs-latest-url]: https://weecology.github.io/Retriever.jl/latest/intro.html
+[docs-stable-img]: https://img.shields.io/badge/docs-stable-green.svg
+[docs-stable-url]: https://weecology.github.io/Retriever.jl/stable/
+[docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
+[docs-latest-url]: https://weecology.github.io/Retriever.jl/dev/
 [travis-img]: https://travis-ci.org/weecology/Retriever.jl.svg?branch=master
 [travis-url]: https://travis-ci.org/weecology/Retriever.jl
 [license-img]: http://img.shields.io/badge/license-MIT-blue.svg


### PR DESCRIPTION

DocumenterTools changed the url structure so this updates to match.
Also replaces the readthedocs badge with a static badge for stable docs